### PR TITLE
Remove memory stress test

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Um compilador completo implementado em C seguindo as especificações ISO/IEC 98
 - Alocação e liberação automática
 - Detecção de vazamentos de memória
 - Guardas de memória para detecção de corrupção
-- Testes de estresse automáticos
 - Relatórios detalhados de uso
 - Limite configurável (padrão: 2048 KB)
 
@@ -160,7 +159,6 @@ c-compiler/
 - Verificação de escopo
 
 ### Testes de Integridade
-- Testes de estresse de memória automáticos
 - Validação de integridade da memória
 - Detecção de corrupção de dados
 

--- a/TODO.md
+++ b/TODO.md
@@ -20,7 +20,6 @@
 - [x] Relatórios de uso de memória
 - [x] Verificação de limites
 - [x] Guardas de memória e detecção de corrupção
-- [x] Teste de estresse de memória
 - [x] Validação de integridade da memória
 - [x] Relatórios detalhados de memória
 
@@ -93,7 +92,6 @@
 - [x] Sistema de debug avançado com guardas de memória
 - [x] Detecção de corrupção de memória
 - [x] Rastreamento detalhado de alocações
-- [x] Testes de estresse automáticos
 - [x] Relatórios detalhados de uso e fragmentação
 - [x] Validação de integridade da memória
 

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -281,7 +281,6 @@ void* memory_realloc_debug(MemoryManager* mm, void* ptr, size_t new_size, const 
 void memory_report(MemoryManager* mm);
 void memory_report_detailed(MemoryManager* mm);
 int memory_check_limit(MemoryManager* mm);
-int memory_stress_test(MemoryManager* mm);
 int memory_validate_integrity(MemoryManager* mm);
 
 /* Macros para facilitar debug de memória */

--- a/src/main.c
+++ b/src/main.c
@@ -209,15 +209,6 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     
-    /* Executar teste de estresse da memória */
-    printf("=== TESTE DE ESTRESSE DA MEMÓRIA ===\n");
-    int memory_test_ok = memory_stress_test(g_memory_manager);
-    if (memory_test_ok) {
-        printf("Teste de memória PASSOU!\n");
-    } else {
-        printf("Teste de memória FALHOU!\n");
-    }
-    
     /* Validar integridade da memória */
     memory_validate_integrity(g_memory_manager);
     

--- a/src/memory.c
+++ b/src/memory.c
@@ -463,62 +463,6 @@ void memory_report_detailed(MemoryManager* mm) {
     printf("=====================================\n\n");
 }
 
-/* Executar teste de estresse de memória */
-int memory_stress_test(MemoryManager* mm) {
-    if (!mm) return 0;
-    
-    printf("=== TESTE DE ESTRESSE DE MEMÓRIA ===\n");
-    
-    const int test_iterations = 1000;
-    const size_t test_sizes[] = {16, 32, 64, 128, 256, 512, 1024, 2048};
-    const int num_sizes = sizeof(test_sizes) / sizeof(test_sizes[0]);
-    
-    void* pointers[test_iterations];
-    int allocated_count = 0;
-    
-    /* Teste de alocação */
-    for (int i = 0; i < test_iterations; i++) {
-        size_t size = test_sizes[i % num_sizes];
-        pointers[i] = memory_alloc(mm, size);
-        
-        if (pointers[i]) {
-            allocated_count++;
-        } else {
-            printf("Falha na alocação %d (tamanho %zu)\n", i, size);
-            break;
-        }
-        
-        /* Verificar limite a cada 100 alocações */
-        if (i % 100 == 0) {
-            int warning_level = memory_check_limit(mm);
-            if (warning_level >= 2) {
-                printf("Limite de memória atingido após %d alocações\n", i);
-                break;
-            }
-        }
-    }
-    
-    printf("Alocações bem-sucedidas: %d/%d\n", allocated_count, test_iterations);
-    
-    /* Teste de liberação */
-    for (int i = 0; i < allocated_count; i++) {
-        if (pointers[i]) {
-            memory_free(mm, pointers[i]);
-            pointers[i] = NULL;
-        }
-    }
-    
-    /* Verificar vazamentos */
-    InternalMemoryManager* imm = (InternalMemoryManager*)mm;
-    if (imm->active_blocks == 0) {
-        printf("Teste de estresse PASSOU - nenhum vazamento detectado!\n");
-        return 1;
-    } else {
-        printf("Teste de estresse FALHOU - %d blocos não foram liberados\n", imm->active_blocks);
-        return 0;
-    }
-}
-
 /* Validar integridade da memória */
 int memory_validate_integrity(MemoryManager* mm) {
     if (!mm) return 0;


### PR DESCRIPTION
## Summary
- delete the unused memory stress test function
- remove calls to the stress test
- update function prototypes and docs

## Testing
- `make clean && make`
- `make test` *(fails: program exits with error)*

------
https://chatgpt.com/codex/tasks/task_e_686e782c6ecc832bb5e1d48aff4000d9