### PR TITLE
Improve error handling

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -207,7 +207,19 @@ static Token read_identifier(Lexer* lexer) {
             token.type = lexer_get_keyword_type(buffer);
         } else {
             token.type = TOKEN_ERROR;
-            snprintf(token.value, MAX_TOKEN_LENGTH, "Identificador deve começar com ! para variáveis ou __ para funções");
+            if (buffer[0] == '!' || (buffer[0] == '_' && buffer[1] == '_')) {
+                snprintf(token.value, MAX_TOKEN_LENGTH,
+                         "Identificador malformado: '%s'",
+                         buffer);
+            } else if (isalpha((unsigned char)buffer[0])) {
+                snprintf(token.value, MAX_TOKEN_LENGTH,
+                         "Identificador deve começar com ! para variáveis ou __ para funções: '%s'",
+                         buffer);
+            } else {
+                snprintf(token.value, MAX_TOKEN_LENGTH,
+                         "Palavra-chave inválida ou identificador desconhecido: '%s'",
+                         buffer);
+            }
             lexer->error_count++;
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -66,24 +66,24 @@ void test_parser(const char* source_code) {
     printf("=== ESTATÍSTICAS SINTÁTICAS ===\n");
     printf("Erros léxicos: %d\n", lexer->error_count);
     printf("Erros sintáticos: %d\n", parser->error_count);
-    
-    if (ast) {
+
+    if (lexer->error_count > 0 || parser->error_count > 0 || !ast) {
+        printf("Nenhuma AST gerada devido a erros\n");
+    } else {
         /* Imprimir AST */
         ast_print(ast, 0);
-        
+
         /* Análise semântica */
         printf("\n=== TESTANDO ANALISADOR SEMÂNTICO ===\n");
         int semantic_ok = semantic_analyze(ast, parser->symbol_table);
-        
+
         if (semantic_ok) {
             printf("Análise semântica concluída com sucesso!\n");
         } else {
             printf("Erros semânticos encontrados.\n");
         }
-        
+
         ast_destroy(ast);
-    } else {
-        printf("Nenhuma AST gerada devido a erros\n");
     }
     
     /* Limpar */
@@ -114,17 +114,18 @@ void test_interpreter(const char* source_code) {
     
     /* Analisar código */
     ASTNode* ast = parser_parse(parser);
-    
-    if (!ast) {
+
+    if (lexer->error_count > 0 || parser->error_count > 0 || !ast) {
         printf("Erro na análise sintática - não é possível executar\n");
         parser_destroy(parser);
         lexer_destroy(lexer);
+        if (ast) ast_destroy(ast);
         return;
     }
-    
+
     /* Análise semântica */
     int semantic_ok = semantic_analyze(ast, parser->symbol_table);
-    
+
     if (!semantic_ok) {
         printf("Erro na análise semântica - não é possível executar\n");
         ast_destroy(ast);


### PR DESCRIPTION
## Summary
- improve lexical error message for unknown tokens
- skip semantic analysis and interpreter when lexer or parser reports errors

## Testing
- `make test`
- `bin/compiler /tmp/test_error.txt`
- `bin/compiler examples/error_test.txt`


------
https://chatgpt.com/codex/tasks/task_e_686f0b22e5b4832ba0a29b9bb5fba7d9