### PR TITLE
Improve memory tracking and reporting

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -166,6 +166,7 @@ typedef struct {
     size_t limit;
     int allocation_count;
     int deallocation_count;
+    size_t process_peak_usage; /* Pico de memória do processo */
 } MemoryManager;
 
 /* Tipos de erro */
@@ -282,6 +283,7 @@ void memory_report(MemoryManager* mm);
 void memory_report_detailed(MemoryManager* mm);
 int memory_check_limit(MemoryManager* mm);
 int memory_validate_integrity(MemoryManager* mm);
+size_t memory_get_process_usage(void);
 
 /* Macros para facilitar debug de memória */
 #define MEMORY_ALLOC(mm, size) memory_alloc_debug(mm, size, __FILE__, __LINE__, __func__)

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -140,7 +140,7 @@ static void copy_runtime_value(RuntimeValue* dest, RuntimeValue* src) {
             break;
         case TYPE_TEXTO:
             if (src->value.string_val) {
-                dest->value.string_val = strdup(src->value.string_val);
+                dest->value.string_val = string_duplicate(src->value.string_val);
             } else {
                 dest->value.string_val = NULL;
             }


### PR DESCRIPTION
## Summary
- track memory using the current process usage
- report the current usage and process peak in memory reports
- update limit checks to examine process memory
- ensure source files end with newlines

## Testing
- `make clean && make`
- `make test </dev/null`

------
https://chatgpt.com/codex/tasks/task_e_687070c7bec0832b951d0751aa15b99d